### PR TITLE
.env file not accessible by app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN php artisan storage:link
 # change permissions and set document root
 RUN sed -i "s/html/html\/public/g" /etc/apache2/sites-enabled/000-default.conf
 RUN chown -R www-data:www-data /var/www/html/* && chmod -R 755 /var/www/html/*
+RUN chown www-data:www-data .env && chmod -R 755 .env
 RUN service apache2 restart
 USER www-data
 


### PR DESCRIPTION
Seems that .env isn't affected whith previous chown and chmod, making it not accessible by app. Therefore, we couldn't change coordinatorr mode via app itself.